### PR TITLE
Fix Spy for Load Balancers Create

### DIFF
--- a/pkg/extra/do/spycloud/client.go
+++ b/pkg/extra/do/spycloud/client.go
@@ -357,7 +357,7 @@ func (client *client) interceptTagDelete(ctx context.Context, name string) error
 }
 
 func (client *client) interceptLoadBalancerCreate(ctx context.Context, name, region string, rules []godo.ForwardingRule, opts ...loadbalancers.CreateOpt) (loadbalancers.LoadBalancer, error) {
-	l, err := client.real.LoadBalancers().Create(ctx, name, region, rules)
+	l, err := client.real.LoadBalancers().Create(ctx, name, region, rules, opts...)
 	if err == nil {
 		client.mu.Lock()
 		defer client.mu.Unlock()


### PR DESCRIPTION
It's funny how one little bug can bite you. Fixing this so we can override params in Load Balancer creates.