### PR TITLE
Make volume attach and detach synchronous

### DIFF
--- a/internal/godoutil/wait.go
+++ b/internal/godoutil/wait.go
@@ -1,4 +1,4 @@
-package droplets
+package godoutil
 
 import (
 	"context"
@@ -11,8 +11,8 @@ import (
 	"github.com/digitalocean/godo"
 )
 
-// waitForActions loops through each actions in godo links and wait until they finish
-func waitForActions(ctx context.Context, cloud *godo.Client, links *godo.Links) error {
+// WaitForActions loops through each actions in godo links and wait until they finish
+func WaitForActions(ctx context.Context, cloud *godo.Client, links *godo.Links) error {
 	if links == nil {
 		return nil
 	}
@@ -25,15 +25,15 @@ func waitForActions(ctx context.Context, cloud *godo.Client, links *godo.Links) 
 		if err != nil {
 			return err
 		}
-		if err := waitForAction(ctx, cloud, action); err != nil {
+		if err := WaitForAction(ctx, cloud, action); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// waitForAction waits for a single action to finish.
-func waitForAction(ctx context.Context, cloud *godo.Client, action *godo.Action) error {
+// WaitForAction waits for a single action to finish.
+func WaitForAction(ctx context.Context, cloud *godo.Client, action *godo.Action) error {
 	if action == nil {
 		return nil
 	}

--- a/pkg/extra/do/cloud/droplets/action.go
+++ b/pkg/extra/do/cloud/droplets/action.go
@@ -3,6 +3,7 @@ package droplets
 import (
 	"context"
 
+	"github.com/aybabtme/godotto/internal/godoutil"
 	"github.com/digitalocean/godo"
 )
 
@@ -37,7 +38,7 @@ func (svc *actionClient) Shutdown(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) PowerOff(ctx context.Context, dropletID int) error {
@@ -45,7 +46,7 @@ func (svc *actionClient) PowerOff(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) PowerOn(ctx context.Context, dropletID int) error {
@@ -53,7 +54,7 @@ func (svc *actionClient) PowerOn(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) PowerCycle(ctx context.Context, dropletID int) error {
@@ -61,7 +62,7 @@ func (svc *actionClient) PowerCycle(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Reboot(ctx context.Context, dropletID int) error {
@@ -69,7 +70,7 @@ func (svc *actionClient) Reboot(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Restore(ctx context.Context, dropletID, imageID int) error {
@@ -77,7 +78,7 @@ func (svc *actionClient) Restore(ctx context.Context, dropletID, imageID int) er
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Resize(ctx context.Context, dropletID int, sizeSlug string, resizeDisk bool) error {
@@ -85,7 +86,7 @@ func (svc *actionClient) Resize(ctx context.Context, dropletID int, sizeSlug str
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Rename(ctx context.Context, dropletID int, name string) error {
@@ -93,7 +94,7 @@ func (svc *actionClient) Rename(ctx context.Context, dropletID int, name string)
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Snapshot(ctx context.Context, dropletID int, name string) error {
@@ -101,7 +102,7 @@ func (svc *actionClient) Snapshot(ctx context.Context, dropletID int, name strin
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) EnableBackups(ctx context.Context, dropletID int) error {
@@ -109,7 +110,7 @@ func (svc *actionClient) EnableBackups(ctx context.Context, dropletID int) error
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) DisableBackups(ctx context.Context, dropletID int) error {
@@ -117,7 +118,7 @@ func (svc *actionClient) DisableBackups(ctx context.Context, dropletID int) erro
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) PasswordReset(ctx context.Context, dropletID int) error {
@@ -125,7 +126,7 @@ func (svc *actionClient) PasswordReset(ctx context.Context, dropletID int) error
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) RebuildByImageID(ctx context.Context, dropletID int, imageID int) error {
@@ -133,7 +134,7 @@ func (svc *actionClient) RebuildByImageID(ctx context.Context, dropletID int, im
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) RebuildByImageSlug(ctx context.Context, dropletID int, imageSlug string) error {
@@ -141,7 +142,7 @@ func (svc *actionClient) RebuildByImageSlug(ctx context.Context, dropletID int, 
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) ChangeKernel(ctx context.Context, dropletID int, kernelID int) error {
@@ -149,7 +150,7 @@ func (svc *actionClient) ChangeKernel(ctx context.Context, dropletID int, kernel
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) EnableIPv6(ctx context.Context, dropletID int) error {
@@ -157,7 +158,7 @@ func (svc *actionClient) EnableIPv6(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) EnablePrivateNetworking(ctx context.Context, dropletID int) error {
@@ -165,7 +166,7 @@ func (svc *actionClient) EnablePrivateNetworking(ctx context.Context, dropletID 
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Upgrade(ctx context.Context, dropletID int) error {
@@ -173,5 +174,5 @@ func (svc *actionClient) Upgrade(ctx context.Context, dropletID int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }

--- a/pkg/extra/do/cloud/droplets/client.go
+++ b/pkg/extra/do/cloud/droplets/client.go
@@ -67,7 +67,7 @@ func (svc *client) Create(ctx context.Context, name, region, size, image string,
 		return nil, err
 	}
 
-	return &droplet{g: svc.g, d: d}, waitForActions(ctx, svc.g, resp.Links)
+	return &droplet{g: svc.g, d: d}, godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *client) Get(ctx context.Context, id int) (Droplet, error) {
@@ -83,7 +83,7 @@ func (svc *client) Delete(ctx context.Context, id int) error {
 	if err != nil {
 		return err
 	}
-	return waitForActions(ctx, svc.g, resp.Links)
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *client) List(ctx context.Context) (<-chan Droplet, <-chan error) {

--- a/pkg/extra/do/cloud/volumes/action.go
+++ b/pkg/extra/do/cloud/volumes/action.go
@@ -3,6 +3,7 @@ package volumes
 import (
 	"context"
 
+	"github.com/aybabtme/godotto/internal/godoutil"
 	"github.com/digitalocean/godo"
 )
 
@@ -17,11 +18,17 @@ type actionClient struct {
 }
 
 func (svc *actionClient) Attach(ctx context.Context, driveID string, dropletID int) error {
-	_, _, err := svc.g.StorageActions.Attach(ctx, driveID, dropletID)
-	return err
+	action, _, err := svc.g.StorageActions.Attach(ctx, driveID, dropletID)
+	if err != nil {
+		return err
+	}
+	return godoutil.WaitForAction(ctx, svc.g, action)
 }
 
 func (svc *actionClient) DetachByDropletID(ctx context.Context, volumeID string, dropletID int) error {
-	_, _, err := svc.g.StorageActions.DetachByDropletID(ctx, volumeID, dropletID)
-	return err
+	action, _, err := svc.g.StorageActions.DetachByDropletID(ctx, volumeID, dropletID)
+	if err != nil {
+		return err
+	}
+	return godoutil.WaitForAction(ctx, svc.g, action)
 }


### PR DESCRIPTION
Wait for volume attach and detach actions to complete before returning. This makes these asynchronous API calls appear synchronous to callers, similar to how we treat droplet creation and deletion.