### PR TITLE
Add support for async (create/delete/actions) floating_ips requests.

### DIFF
--- a/pkg/extra/do/cloud/floatingips/action.go
+++ b/pkg/extra/do/cloud/floatingips/action.go
@@ -3,6 +3,7 @@ package floatingips
 import (
 	"context"
 
+	"github.com/aybabtme/godotto/internal/godoutil"
 	"github.com/digitalocean/godo"
 )
 
@@ -17,11 +18,19 @@ type actionClient struct {
 }
 
 func (svc *actionClient) Assign(ctx context.Context, ip string, dropletID int) error {
-	_, _, err := svc.g.FloatingIPActions.Assign(ctx, ip, dropletID)
-	return err
+	_, resp, err := svc.g.FloatingIPActions.Assign(ctx, ip, dropletID)
+	if err != nil {
+		return err
+	}
+
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *actionClient) Unassign(ctx context.Context, ip string) error {
-	_, _, err := svc.g.FloatingIPActions.Unassign(ctx, ip)
-	return err
+	_, resp, err := svc.g.FloatingIPActions.Unassign(ctx, ip)
+	if err != nil {
+		return err
+	}
+
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }

--- a/pkg/extra/do/cloud/floatingips/client.go
+++ b/pkg/extra/do/cloud/floatingips/client.go
@@ -57,11 +57,11 @@ func (svc *client) Create(ctx context.Context, region string, opts ...CreateOpt)
 	for _, fn := range opts {
 		fn(opt)
 	}
-	d, _, err := svc.g.FloatingIPs.Create(ctx, opt.req)
+	d, resp, err := svc.g.FloatingIPs.Create(ctx, opt.req)
 	if err != nil {
 		return nil, err
 	}
-	return &floatingIP{g: svc.g, d: d}, nil
+	return &floatingIP{g: svc.g, d: d}, godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *client) Get(ctx context.Context, ip string) (FloatingIP, error) {
@@ -73,8 +73,12 @@ func (svc *client) Get(ctx context.Context, ip string) (FloatingIP, error) {
 }
 
 func (svc *client) Delete(ctx context.Context, ip string) error {
-	_, err := svc.g.FloatingIPs.Delete(ctx, ip)
-	return err
+	resp, err := svc.g.FloatingIPs.Delete(ctx, ip)
+	if err != nil {
+		return err
+	}
+
+	return godoutil.WaitForActions(ctx, svc.g, resp.Links)
 }
 
 func (svc *client) List(ctx context.Context) (<-chan FloatingIP, <-chan error) {


### PR DESCRIPTION
Other async requests in godotto follow a pattern of issuing the action then polling the associated /resource/:id/actions endpoint to wait for the completion of the action.

For example Droplet Create does just that. 
The floating IP assign/unassign actions do not currently have the wait support so assertions against their state are flappy.