### PR TITLE
Fix CreateMultiple functionality

### DIFF
--- a/pkg/extra/do/cloud/droplets/client.go
+++ b/pkg/extra/do/cloud/droplets/client.go
@@ -99,17 +99,18 @@ func (svc *client) CreateMultiple(ctx context.Context, names []string, region, s
 	opt.req.Region = region
 	opt.req.Image.Slug = image
 
-	r, resp, err := svc.g.Droplets.CreateMultiple(ctx, opt.req)
+	r, _, err := svc.g.Droplets.CreateMultiple(ctx, opt.req)
 	if err != nil {
 		return nil, err
 	}
 
 	droplets := make([]Droplet, 0, len(r))
 	for _, d := range r {
-		droplets = append(droplets, &droplet{g: svc.g, d: &d})
+		dd := d
+		droplets = append(droplets, &droplet{g: svc.g, d: &dd})
 	}
 
-	return droplets, godoutil.WaitForActions(ctx, svc.g, resp.Links)
+	return droplets, nil
 }
 
 func (svc *client) Get(ctx context.Context, id int) (Droplet, error) {

--- a/pkg/extra/do/spycloud/client.go
+++ b/pkg/extra/do/spycloud/client.go
@@ -207,8 +207,8 @@ func (client *client) interceptDropletCreateMultiple(ctx context.Context, names 
 	if err == nil {
 		for _, d := range droplets {
 			client.mu.Lock()
-			defer client.mu.Unlock()
 			client.droplets[d.Struct().ID] = d.Struct()
+			client.mu.Unlock()
 		}
 	}
 


### PR DESCRIPTION
So, we remove WaitForActions from the CreateMultiple call since it returns a 404 anyways. Additionally, we removed the `defer Unlock()` and just unlock it directly from inside of the for loop. So CreateMultiple should be working as expected now.